### PR TITLE
9 setup base rest api client

### DIFF
--- a/overdrive/README.md
+++ b/overdrive/README.md
@@ -1,69 +1,180 @@
 # OverDrive Mobile
 
-Application mobile Flutter du projet OverDrive.
+Flutter mobile client for the OverDrive project.
 
-## Prerequisites
+## Module Purpose
 
-- Flutter SDK installe
-- Dart SDK disponible dans le PATH
+The current app is a base mobile shell with:
+- environment loading at startup
+- a reusable REST client built on Dio
+- a Home screen that calls `/health` and displays API status/time
 
-## Installation
+## Tech Stack
 
-```bash
-flutter pub get
+- Flutter / Dart SDK `^3.10.7`
+- `dio` for HTTP requests
+- `flutter_dotenv` for environment variables
+- `pretty_dio_logger` for request/response logging
+
+## Project Layout
+
+```text
+lib/
+  main.dart
+  features/
+    home/presentation/home_screen.dart
+  services/
+    api_service.dart
+    api_interceptor.dart
+    api_response.dart
+  core/
+    constants/app_constants.dart
+    theme/app_theme.dart
+    utils/logger.dart
+  shared/
+    widgets/app_scaffold.dart
 ```
+
+## Startup Flow
+
+1. `main()` calls `WidgetsFlutterBinding.ensureInitialized()`.
+2. Environment file is loaded from `ENV_FILE` (`.env` by default).
+3. `MyApp` reads `APP_ENV` and injects it into the app title.
+4. The app opens `HomeScreen`.
+
+Code reference: `lib/main.dart`.
+
+## Home Screen Behavior
+
+`HomeScreen` (`lib/features/home/presentation/home_screen.dart`) manages 3 UI states:
+- `idle`
+- `loading`
+- `result`
+
+When the user taps **Check Health**:
+- it calls `ApiService.checkHealth()`
+- on success, it renders `status` and `time` from the JSON response
+- on failure, it renders an error message
+
+## Network Layer
+
+### Architecture
+
+- UI should call `ApiService` only.
+- HTTP client concerns are centralized in `services/`.
+- API results are wrapped in `ApiResponse<T>` to avoid raw exception handling in UI code.
+
+### `ApiService`
+
+`lib/services/api_service.dart`:
+- reads `API_BASE_URL` from `.env`
+- configures Dio with `connectTimeout = 10s` and `receiveTimeout = 10s`
+- registers `ApiInterceptor()` and `PrettyDioLogger(...)`
+- validates `API_BASE_URL` before requests
+- exposes generic `get<T>()` and `checkHealth()` for `GET /health`
+- maps Dio errors to user-facing messages
+
+Important: `PrettyDioLogger` is currently added unconditionally in the constructor.
+
+### `ApiInterceptor`
+
+`lib/services/api_interceptor.dart`:
+- currently extends Dio `Interceptor` with no overrides
+- acts as the insertion point for Bearer token injection, global request/response hooks, and centralized error/reporting policies
+
+### `ApiResponse<T>`
+
+`lib/services/api_response.dart` provides two explicit states:
+- `ApiResponse.success(data)`
+- `ApiResponse.failure(error)`
+
+This keeps UI logic simple (`isSuccess`, `data`, `error`) and avoids `try/catch` in presentation code.
 
 ## Environment Configuration
 
-Le projet utilise `flutter_dotenv` avec deux fichiers:
+The app uses two files:
+- `.env` for development
+- `.env.prod` for production
 
-- `.env` (developpement)
-- `.env.prod` (production)
-
-Variables attendues:
-
+Required variables:
 - `API_BASE_URL`
 - `APP_ENV`
 
-Le chargement de l'environnement se fait dans `lib/main.dart`:
+Local examples:
 
-- par defaut: `.env`
-- surcharge possible avec `--dart-define=ENV_FILE=.env.prod`
-
-## Run
-
-Developpement:
-
-```bash
-flutter run
+```env
+# Android emulator
+API_BASE_URL=http://10.0.2.2:8080
+APP_ENV=dev
 ```
 
-Production (fichier prod):
+```env
+# iOS simulator
+API_BASE_URL=http://localhost:8080
+APP_ENV=dev
+```
+
+Production example:
+
+```env
+API_BASE_URL=https://api.overdrive.com
+APP_ENV=prod
+```
+
+`ENV_FILE` override:
 
 ```bash
 flutter run --dart-define=ENV_FILE=.env.prod
 ```
 
-## Quality
+## Android Networking Setup
 
-Lint:
+`android/app/src/main/AndroidManifest.xml` includes:
+- `android.permission.INTERNET`
+- `android:usesCleartextTraffic="true"` for local HTTP development
+
+## Commands
+
+Install dependencies:
+
+```bash
+flutter pub get
+```
+
+Run in development:
+
+```bash
+flutter run
+```
+
+Run with production environment:
+
+```bash
+flutter run --dart-define=ENV_FILE=.env.prod
+```
+
+Static analysis:
 
 ```bash
 flutter analyze
 ```
 
-Format:
+Format source:
 
 ```bash
 dart format lib/
 ```
 
-Configuration associee:
+## Linting and Style
 
-- `analysis_options.yaml`
-- `.editorconfig`
+- Lint rules are configured in `analysis_options.yaml`.
+- Formatting and indentation are configured in `.editorconfig`.
+- Dart indentation in this project is set to 4 spaces.
 
-## Notes
+## Current Gaps
 
-- `.env` et `.env.prod` sont ignores par Git.
-- Les assets Flutter incluent `.env` et `.env.prod` via `pubspec.yaml`.
+- `core/constants/app_constants.dart` is a placeholder.
+- `core/theme/app_theme.dart` is a placeholder.
+- `core/utils/logger.dart` is a placeholder.
+- `shared/widgets/app_scaffold.dart` is a placeholder.
+- `test/widget_test.dart` is still the default Flutter counter test and does not match current UI.

--- a/overdrive/android/app/src/main/AndroidManifest.xml
+++ b/overdrive/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="overdrive"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/overdrive/lib/core/constants/app_constants.dart
+++ b/overdrive/lib/core/constants/app_constants.dart
@@ -1,4 +1,4 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved

--- a/overdrive/lib/core/theme/app_theme.dart
+++ b/overdrive/lib/core/theme/app_theme.dart
@@ -1,4 +1,4 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved

--- a/overdrive/lib/core/utils/logger.dart
+++ b/overdrive/lib/core/utils/logger.dart
@@ -1,4 +1,4 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved

--- a/overdrive/lib/features/home/presentation/home_screen.dart
+++ b/overdrive/lib/features/home/presentation/home_screen.dart
@@ -1,4 +1,4 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved
@@ -6,3 +6,90 @@
  ## home_screen.dart - Home feature main presentation screen.
  ##
  */
+
+import 'package:flutter/material.dart';
+import '../../../services/api_service.dart';
+
+enum _HealthViewState { idle, loading, result }
+
+class HomeScreen extends StatefulWidget {
+    const HomeScreen({super.key});
+
+    @override
+    State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+    final ApiService _apiService = ApiService();
+
+    _HealthViewState _state = _HealthViewState.idle;
+    String? _status;
+    String? _time;
+    String? _error;
+
+    Future<void> _checkHealth() async {
+        setState(() {
+            _state = _HealthViewState.loading;
+            _status = null;
+            _time = null;
+            _error = null;
+        });
+
+        final response = await _apiService.checkHealth();
+
+        if (!mounted) {
+            return;
+        }
+
+        setState(() {
+            _state = _HealthViewState.result;
+
+            if (response.isSuccess && response.data != null) {
+                final data = response.data!;
+                _status = data['status']?.toString();
+                _time = data['time']?.toString();
+                _error = null;
+            } else {
+                _error = response.error ?? 'Unknown error';
+            }
+        });
+    }
+
+    @override
+    Widget build(BuildContext context) {
+        return Scaffold(
+            body: Center(
+                child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                            ElevatedButton(
+                                onPressed: _state == _HealthViewState.loading
+                                    ? null
+                                    : _checkHealth,
+                                child: const Text('Check Health'),
+                            ),
+                            const SizedBox(height: 16),
+                            if (_state == _HealthViewState.loading)
+                                const CircularProgressIndicator()
+                            else if (_state == _HealthViewState.result &&
+                                _error != null)
+                                Text(
+                                    _error!,
+                                    style: const TextStyle(color: Colors.red),
+                                )
+                            else if (_state == _HealthViewState.result)
+                                Column(
+                                    children: [
+                                        Text('Status: ${_status ?? '-'}'),
+                                        Text('Time: ${_time ?? '-'}'),
+                                    ],
+                                ),
+                        ],
+                    ),
+                ),
+            ),
+        );
+    }
+}

--- a/overdrive/lib/main.dart
+++ b/overdrive/lib/main.dart
@@ -1,4 +1,4 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved
@@ -6,33 +6,28 @@
  ## main.dart - Application entry point and startup configuration.
  ##
  */
+ 
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'features/home/presentation/home_screen.dart';
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  const envFile = String.fromEnvironment('ENV_FILE', defaultValue: '.env');
-  await dotenv.load(fileName: envFile);
-  runApp(const MyApp());
+    WidgetsFlutterBinding.ensureInitialized();
+    const envFile = String.fromEnvironment('ENV_FILE', defaultValue: '.env');
+    await dotenv.load(fileName: envFile);
+    runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+    const MyApp({super.key});
 
-  @override
-  Widget build(BuildContext context) {
-    final appEnv = dotenv.env['APP_ENV'] ?? 'unknown';
+    @override
+    Widget build(BuildContext context) {
+        final appEnv = dotenv.env['APP_ENV'] ?? 'unknown';
 
-    return MaterialApp(
-      title: 'OverDrive ($appEnv)',
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('OverDrive'),
-        ),
-        body: Center(
-          child: Text('Environment: $appEnv'),
-        ),
-      ),
-    );
-  }
+        return MaterialApp(
+            title: 'OverDrive ($appEnv)',
+            home: const HomeScreen(),
+        );
+    }
 }

--- a/overdrive/lib/services/api_interceptor.dart
+++ b/overdrive/lib/services/api_interceptor.dart
@@ -9,4 +9,17 @@
 
 import 'package:dio/dio.dart';
 
-class ApiInterceptor extends Interceptor {}
+class ApiInterceptor extends Interceptor {
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final message = switch (err.type) {
+      DioExceptionType.connectionTimeout || DioExceptionType.receiveTimeout =>
+        'Connection timeout',
+      DioExceptionType.connectionError => 'No internet connection',
+      DioExceptionType.badResponse => 'Server error ${err.response?.statusCode}',
+      _ => 'Unexpected error',
+    };
+
+    handler.next(err.copyWith(error: message));
+  }
+}

--- a/overdrive/lib/services/api_interceptor.dart
+++ b/overdrive/lib/services/api_interceptor.dart
@@ -1,0 +1,12 @@
+/*
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## api_interceptor.dart - Dio interceptor for request/response lifecycle hooks.
+ ##
+ */
+
+import 'package:dio/dio.dart';
+
+class ApiInterceptor extends Interceptor {}

--- a/overdrive/lib/services/api_response.dart
+++ b/overdrive/lib/services/api_response.dart
@@ -1,0 +1,22 @@
+/*
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## api_response.dart - Generic wrapper for API success/failure responses.
+ ##
+ */
+
+class ApiResponse<T> {
+    final T? data;
+    final String? error;
+    final bool isSuccess;
+
+    const ApiResponse.success(this.data)
+        : error = null,
+        isSuccess = true;
+
+    const ApiResponse.failure(this.error)
+        : data = null,
+        isSuccess = false;
+}

--- a/overdrive/lib/services/api_service.dart
+++ b/overdrive/lib/services/api_service.dart
@@ -56,7 +56,11 @@ class ApiService {
         fromJson != null ? fromJson(response.data) : response.data,
       );
     } on DioException catch (e) {
-      return ApiResponse.failure(_handleError(e));
+      final error = e.error;
+      if (error is String && error.trim().isNotEmpty) {
+        return ApiResponse.failure(error);
+      }
+      return ApiResponse.failure(e.message ?? 'Unexpected error');
     }
   }
 
@@ -65,41 +69,5 @@ class ApiService {
       '/health',
       fromJson: (json) => Map<String, dynamic>.from(json as Map),
     );
-  }
-
-  String _handleError(DioException e) {
-    switch (e.type) {
-      case DioExceptionType.connectionTimeout:
-      case DioExceptionType.receiveTimeout:
-        return 'Connection timeout';
-      case DioExceptionType.connectionError:
-        return 'No internet connection';
-      case DioExceptionType.badResponse:
-        return 'Server error ${e.response?.statusCode}';
-      case DioExceptionType.unknown:
-        final errorText = e.error?.toString() ?? '';
-        final messageText = e.message ?? '';
-        final details = '$errorText $messageText'.toLowerCase();
-
-        if (details.contains('cleartext')) {
-          return 'HTTP blocked by Android cleartext policy';
-        }
-
-        if (details.contains('connection refused')) {
-          return 'Cannot reach backend at ${dotenv.env['API_BASE_URL'] ?? ''}';
-        }
-
-        if (messageText.trim().isNotEmpty) {
-          return messageText;
-        }
-
-        if (errorText.trim().isNotEmpty) {
-          return errorText;
-        }
-
-        return 'Unexpected network error';
-      default:
-        return 'Unexpected error';
-    }
   }
 }

--- a/overdrive/lib/services/api_service.dart
+++ b/overdrive/lib/services/api_service.dart
@@ -1,8 +1,105 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved
  ##
- ## api_service.dart - Service layer for backend API communication.
+ ## api_service.dart - Base service for backend API communication.
  ##
  */
+
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
+
+import 'api_interceptor.dart';
+import 'api_response.dart';
+
+class ApiService {
+  late final Dio _dio;
+  late final String _baseUrl;
+
+  ApiService() {
+    _baseUrl = (dotenv.env['API_BASE_URL'] ?? '').trim();
+
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: _baseUrl,
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+
+    _dio.interceptors.addAll([
+      ApiInterceptor(),
+      PrettyDioLogger(
+        requestHeader: true,
+        requestBody: true,
+        responseBody: true,
+      ),
+    ]);
+  }
+
+  Future<ApiResponse<T>> get<T>(
+    String path, {
+    T Function(dynamic)? fromJson,
+  }) async {
+    final baseUri = Uri.tryParse(_baseUrl);
+    if (_baseUrl.isEmpty || baseUri == null || baseUri.host.isEmpty) {
+      return const ApiResponse.failure(
+        'API_BASE_URL is missing or invalid in .env',
+      );
+    }
+
+    try {
+      final response = await _dio.get(path);
+      return ApiResponse.success(
+        fromJson != null ? fromJson(response.data) : response.data,
+      );
+    } on DioException catch (e) {
+      return ApiResponse.failure(_handleError(e));
+    }
+  }
+
+  Future<ApiResponse<Map<String, dynamic>>> checkHealth() {
+    return get<Map<String, dynamic>>(
+      '/health',
+      fromJson: (json) => Map<String, dynamic>.from(json as Map),
+    );
+  }
+
+  String _handleError(DioException e) {
+    switch (e.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.receiveTimeout:
+        return 'Connection timeout';
+      case DioExceptionType.connectionError:
+        return 'No internet connection';
+      case DioExceptionType.badResponse:
+        return 'Server error ${e.response?.statusCode}';
+      case DioExceptionType.unknown:
+        final errorText = e.error?.toString() ?? '';
+        final messageText = e.message ?? '';
+        final details = '$errorText $messageText'.toLowerCase();
+
+        if (details.contains('cleartext')) {
+          return 'HTTP blocked by Android cleartext policy';
+        }
+
+        if (details.contains('connection refused')) {
+          return 'Cannot reach backend at ${dotenv.env['API_BASE_URL'] ?? ''}';
+        }
+
+        if (messageText.trim().isNotEmpty) {
+          return messageText;
+        }
+
+        if (errorText.trim().isNotEmpty) {
+          return errorText;
+        }
+
+        return 'Unexpected network error';
+      default:
+        return 'Unexpected error';
+    }
+  }
+}

--- a/overdrive/lib/shared/widgets/app_scaffold.dart
+++ b/overdrive/lib/shared/widgets/app_scaffold.dart
@@ -1,4 +1,4 @@
-/**
+/*
  ##
  ## OverDrive 2026
  ## All Technical rights reserved

--- a/overdrive/pubspec.lock
+++ b/overdrive/pubspec.lock
@@ -49,6 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -83,6 +99,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -139,6 +163,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -147,6 +179,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  pretty_dio_logger:
+    dependency: "direct main"
+    description:
+      name: pretty_dio_logger
+      sha256: "36f2101299786d567869493e2f5731de61ce130faa14679473b26905a92b6407"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -200,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -216,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.10.7 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/overdrive/pubspec.yaml
+++ b/overdrive/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   flutter_dotenv: ^5.1.0
+  dio: ^5.9.2
+  pretty_dio_logger: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Context
Sets up the base HTTP client for OverDrive. Related to ticket #9 — P0 CRITICAL.
The goal is to have one centralized place that handles all server requests, errors, and timeouts.

## Changes
- Added `Dio` as HTTP client
- Added `pretty_dio_logger` for debug logging
- Created `ApiResponse<T>` wrapper (success / failure)
- Created `ApiInterceptor` with error mapping (timeout, no internet, server errors)
- Created `ApiService` with base URL from `.env`, timeout strategy and centralized error handling
- Added `INTERNET` permission in `AndroidManifest.xml`
- Enabled `usesCleartextTraffic` for local dev (Android)
- Validated with a real `GET /health` call — Status 200 OK in 3ms

## Checks
- [ ] Tests added or updated if necessary
- [x] Docs updated if necessary