### PR TITLE
5 main pages instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,6 @@ The application adapts information density and hierarchy according to the user p
 - Real-time oriented.
 - Compatible with progressive scaling.
 
-<br>
-
-## Contributors
-
-Project developed by the **OverDrive Team – Epitech Paris (2026)**.
-
-| Name            |
-|-----------------|
-| Anthony El Achkar |
-| Clément-Alexis Fournier |
-| Mariia Semenchenko |
-| Batien Leroux |
-| Corto Morrow |
 
 <br>
 
@@ -82,18 +69,18 @@ cd OD_Mobile
 
 ### Mobile App (Flutter)
 
-Le module mobile se trouve dans `overdrive/`.
+The mobile module is located in overdrive/`.
 
-État actuel du module mobile :
+Current state of the mobile module:
 
-- écran `Home` avec menu overlay
-- pages placeholders `Profil`, `Settings`, `Calendar`, `Championship`, `TV`, `Telemetry` et `Search`
-- fond noir uni sur ces écrans
-- vérification backend conservée via `GET /health`
+- `Home`screen with menu overlay
+- pages placeholders `Profil`, `Settings`, `Calendar`, `Championship`, `TV`, `Telemetry` and `Search`
+- solid black background on all screens
+- backend health check retained via `GET /health`
 
 Convention de code :
 
-- tous les fichiers Dart sous `overdrive/lib/` utilisent désormais un header standardisé avec le nom du fichier et une courte description
+- all Dart files under `overdrive/lib/`     now use a standardized header including the file name and a short descriptio
 
 ```bash
 cd overdrive
@@ -135,6 +122,20 @@ Lint and formatting configuration is defined in:
 - `overdrive/.editorconfig`
 
 More details for the Flutter app are available in `overdrive/README.md`.
+
+<br>
+
+## Contributors
+
+Project developed by the **OverDrive Team – Epitech Paris (2026)**.
+
+| Name            |
+|-----------------|
+| Anthony El Achkar |
+| Clément-Alexis Fournier |
+| Mariia Semenchenko |
+| Batien Leroux |
+| Corto Morrow |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ cd OD_Mobile
 
 Le module mobile se trouve dans `overdrive/`.
 
+État actuel du module mobile :
+
+- écran `Home` avec menu overlay
+- pages placeholders `Profil`, `Settings`, `Calendar`, `Championship`, `TV`, `Telemetry` et `Search`
+- fond noir uni sur ces écrans
+- vérification backend conservée via `GET /health`
+
+Convention de code :
+
+- tous les fichiers Dart sous `overdrive/lib/` utilisent désormais un header standardisé avec le nom du fichier et une courte description
+
 ```bash
 cd overdrive
 flutter pub get

--- a/overdrive/README.md
+++ b/overdrive/README.md
@@ -1,6 +1,6 @@
 # OverDrive
 
-Application Flutter minimaliste avec une seule page `Home`.
+Application Flutter minimaliste centrée sur une page `Home` et plusieurs pages placeholders accessibles depuis le menu.
 
 Documentation détaillée :
 
@@ -8,11 +8,34 @@ Documentation détaillée :
 
 ## Structure actuelle
 
-- `lib/main.dart` lance directement `HomePage`
-- `lib/pages/home/home_page.dart` contient uniquement le fond de page et le menu
-- `lib/widgets/menu_overlay.dart` affiche `OD`, le bouton `Menu` et l'action `Health`
+- `lib/main.dart` lance directement `HomePage` et configure le thème global
+- `lib/pages/home/home_page.dart` affiche l'écran d'accueil avec fond noir uni
+- `lib/widgets/menu_overlay.dart` affiche `OD`, le bouton `Menu`, les raccourcis de navigation et l'action `Health`
+- `lib/pages/shared/placeholder_page.dart` fournit un écran placeholder réutilisable avec titre centré
+- `lib/pages/profile/profile_page.dart` affiche la page `Profil`
+- `lib/pages/settings/settings_page.dart` affiche la page `Settings`
+- `lib/pages/calendar/calendar_page.dart` affiche la page `Calendar`
+- `lib/pages/championship/championship_page.dart` affiche la page `Championship`
+- `lib/pages/tv/tv_page.dart` affiche la page `TV`
+- `lib/pages/telemetry/telemetry_page.dart` affiche la page `Telemetry`
+- `lib/pages/search/search_page.dart` affiche la page `Search`
 - `lib/services/health_service.dart` gère l'unique interaction backend: `GET /health`
-- `lib/core/theme/app_theme.dart` centralise le thème et les styles
+- `lib/core/theme/app_theme.dart` centralise le thème, les couleurs et les styles
+
+## Convention de header
+
+Tous les fichiers Dart dans `lib/` commencent désormais par le header standard suivant, adapté à chaque fichier :
+
+```dart
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## [FileName] - [Brief description of the file's purpose]
+ ##
+ */
+```
 
 ## Backend
 
@@ -27,4 +50,13 @@ L'URL du backend est lue depuis `API_BASE_URL` si elle est définie. Sinon l'app
 
 ## Tests
 
-Le test widget vérifie que la home affiche bien `OD` et le bouton `Menu`.
+Le test widget historique vérifie que la home affiche bien `OD` et le bouton `Menu`.
+
+## Qualité de code
+
+Commandes utiles :
+
+```bash
+dart format lib
+flutter analyze
+```

--- a/overdrive/README.md
+++ b/overdrive/README.md
@@ -2,6 +2,10 @@
 
 Application Flutter minimaliste avec une seule page `Home`.
 
+Documentation détaillée :
+
+- `ARCHITECTURE_LIB.md`
+
 ## Structure actuelle
 
 - `lib/main.dart` lance directement `HomePage`

--- a/overdrive/README.md
+++ b/overdrive/README.md
@@ -1,30 +1,30 @@
 # OverDrive
 
-Application Flutter minimaliste centrée sur une page `Home` et plusieurs pages placeholders accessibles depuis le menu.
+A minimalist Flutter application focused on a `Home` page and several placeholder pages accessible from the menu.
 
-Documentation détaillée :
+## Detailed Documentation
 
 - `ARCHITECTURE_LIB.md`
 
-## Structure actuelle
+## Current Structure
 
-- `lib/main.dart` lance directement `HomePage` et configure le thème global
-- `lib/pages/home/home_page.dart` affiche l'écran d'accueil avec fond noir uni
-- `lib/widgets/menu_overlay.dart` affiche `OD`, le bouton `Menu`, les raccourcis de navigation et l'action `Health`
-- `lib/pages/shared/placeholder_page.dart` fournit un écran placeholder réutilisable avec titre centré
-- `lib/pages/profile/profile_page.dart` affiche la page `Profil`
-- `lib/pages/settings/settings_page.dart` affiche la page `Settings`
-- `lib/pages/calendar/calendar_page.dart` affiche la page `Calendar`
-- `lib/pages/championship/championship_page.dart` affiche la page `Championship`
-- `lib/pages/tv/tv_page.dart` affiche la page `TV`
-- `lib/pages/telemetry/telemetry_page.dart` affiche la page `Telemetry`
-- `lib/pages/search/search_page.dart` affiche la page `Search`
-- `lib/services/health_service.dart` gère l'unique interaction backend: `GET /health`
-- `lib/core/theme/app_theme.dart` centralise le thème, les couleurs et les styles
+- `lib/main.dart` directly launches `HomePage` and configures the global theme  
+- `lib/pages/home/home_page.dart` displays the home screen with a solid black background  
+- `lib/widgets/menu_overlay.dart` displays `OD`, the `Menu` button, navigation shortcuts, and the `Health` action  
+- `lib/pages/shared/placeholder_page.dart` provides a reusable placeholder screen with a centered title  
+- `lib/pages/profile/profile_page.dart` displays the `Profile` page  
+- `lib/pages/settings/settings_page.dart` displays the `Settings` page  
+- `lib/pages/calendar/calendar_page.dart` displays the `Calendar` page  
+- `lib/pages/championship/championship_page.dart` displays the `Championship` page  
+- `lib/pages/tv/tv_page.dart` displays the `TV` page  
+- `lib/pages/telemetry/telemetry_page.dart` displays the `Telemetry` page  
+- `lib/pages/search/search_page.dart` displays the `Search` page  
+- `lib/services/health_service.dart` handles the only backend interaction: `GET /health`  
+- `lib/core/theme/app_theme.dart` centralizes the theme, colors, and styles  
 
-## Convention de header
+## Header Convention
 
-Tous les fichiers Dart dans `lib/` commencent désormais par le header standard suivant, adapté à chaque fichier :
+All Dart files in `lib/` now start with the following standard header, adapted to each file:
 
 ```dart
 /**
@@ -35,26 +35,25 @@ Tous les fichiers Dart dans `lib/` commencent désormais par le header standard 
  ## [FileName] - [Brief description of the file's purpose]
  ##
  */
-```
 
 ## Backend
 
-La seule interaction backend conservée est:
+The only backend interaction retained is:
 
 - `GET /health`
 
-L'URL du backend est lue depuis `API_BASE_URL` si elle est définie. Sinon l'application utilise:
+The backend URL is read from API_BASE_URL if defined. Otherwise, the application uses:
 
 - `http://10.0.2.2:8080` sur Android
 - `http://localhost:8080` ailleurs
 
 ## Tests
 
-Le test widget historique vérifie que la home affiche bien `OD` et le bouton `Menu`.
+The existing widget test verifies that the home screen correctly displays OD and the Menu button.
 
-## Qualité de code
+## Code Quality
 
-Commandes utiles :
+Useful commands :
 
 ```bash
 dart format lib

--- a/overdrive/lib/core/theme/app_theme.dart
+++ b/overdrive/lib/core/theme/app_theme.dart
@@ -1,4 +1,4 @@
-/*
+/**
  ##
  ## OverDrive 2026
  ## All Technical rights reserved

--- a/overdrive/lib/main.dart
+++ b/overdrive/lib/main.dart
@@ -1,9 +1,9 @@
-/*
+/**
  ##
  ## OverDrive 2026
  ## All Technical rights reserved
  ##
- ## main.dart - Application entry point.
+ ## main.dart - Application entry point and root app setup.
  ##
  */
 

--- a/overdrive/lib/pages/calendar/calendar_page.dart
+++ b/overdrive/lib/pages/calendar/calendar_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class CalendarPage extends StatelessWidget {
+  const CalendarPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'Calendar');
+  }
+}

--- a/overdrive/lib/pages/calendar/calendar_page.dart
+++ b/overdrive/lib/pages/calendar/calendar_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## calendar_page.dart - Calendar screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/championship/championship_page.dart
+++ b/overdrive/lib/pages/championship/championship_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class ChampionshipPage extends StatelessWidget {
+  const ChampionshipPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'Championship');
+  }
+}

--- a/overdrive/lib/pages/championship/championship_page.dart
+++ b/overdrive/lib/pages/championship/championship_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## championship_page.dart - Championship screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/home/home_page.dart
+++ b/overdrive/lib/pages/home/home_page.dart
@@ -16,14 +16,9 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      body: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [AppColors.background, Color(0xFF050505)],
-          ),
-        ),
+      backgroundColor: AppColors.black,
+      body: ColoredBox(
+        color: AppColors.black,
         child: Stack(children: [MenuOverlay()]),
       ),
     );

--- a/overdrive/lib/pages/home/home_page.dart
+++ b/overdrive/lib/pages/home/home_page.dart
@@ -1,7 +1,9 @@
-/*
+/**
  ##
- ## OverDrive 2026 — home_page.dart
- ## Minimal home page with the application menu overlay.
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## home_page.dart - Home screen with the application menu overlay.
  ##
  */
 

--- a/overdrive/lib/pages/profile/profile_page.dart
+++ b/overdrive/lib/pages/profile/profile_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'Profil');
+  }
+}

--- a/overdrive/lib/pages/profile/profile_page.dart
+++ b/overdrive/lib/pages/profile/profile_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## profile_page.dart - Profile screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/search/search_page.dart
+++ b/overdrive/lib/pages/search/search_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## search_page.dart - Search screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/search/search_page.dart
+++ b/overdrive/lib/pages/search/search_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class SearchPage extends StatelessWidget {
+  const SearchPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'Search');
+  }
+}

--- a/overdrive/lib/pages/settings/settings_page.dart
+++ b/overdrive/lib/pages/settings/settings_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## settings_page.dart - Settings screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/settings/settings_page.dart
+++ b/overdrive/lib/pages/settings/settings_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'Settings');
+  }
+}

--- a/overdrive/lib/pages/shared/placeholder_page.dart
+++ b/overdrive/lib/pages/shared/placeholder_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## placeholder_page.dart - Reusable placeholder screen with centered page title.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../../core/theme/app_theme.dart';

--- a/overdrive/lib/pages/shared/placeholder_page.dart
+++ b/overdrive/lib/pages/shared/placeholder_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/theme/app_theme.dart';
+import '../../widgets/menu_overlay.dart';
 
 class PlaceholderPage extends StatelessWidget {
   const PlaceholderPage({required this.title, super.key});
@@ -11,8 +12,16 @@ class PlaceholderPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.black,
-      body: SafeArea(
-        child: Center(child: Text(title, style: AppTextStyles.display())),
+      body: ColoredBox(
+        color: AppColors.black,
+        child: Stack(
+          children: [
+            SafeArea(
+              child: Center(child: Text(title, style: AppTextStyles.display())),
+            ),
+            const MenuOverlay(),
+          ],
+        ),
       ),
     );
   }

--- a/overdrive/lib/pages/shared/placeholder_page.dart
+++ b/overdrive/lib/pages/shared/placeholder_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/app_theme.dart';
+
+class PlaceholderPage extends StatelessWidget {
+  const PlaceholderPage({required this.title, super.key});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.black,
+      body: SafeArea(
+        child: Center(child: Text(title, style: AppTextStyles.display())),
+      ),
+    );
+  }
+}

--- a/overdrive/lib/pages/telemetry/telemetry_page.dart
+++ b/overdrive/lib/pages/telemetry/telemetry_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## telemetry_page.dart - Telemetry screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/telemetry/telemetry_page.dart
+++ b/overdrive/lib/pages/telemetry/telemetry_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class TelemetryPage extends StatelessWidget {
+  const TelemetryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'Telemetry');
+  }
+}

--- a/overdrive/lib/pages/tv/tv_page.dart
+++ b/overdrive/lib/pages/tv/tv_page.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## tv_page.dart - TV screen placeholder.
+ ##
+ */
+
 import 'package:flutter/material.dart';
 
 import '../shared/placeholder_page.dart';

--- a/overdrive/lib/pages/tv/tv_page.dart
+++ b/overdrive/lib/pages/tv/tv_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../shared/placeholder_page.dart';
+
+class TvPage extends StatelessWidget {
+  const TvPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PlaceholderPage(title: 'TV');
+  }
+}

--- a/overdrive/lib/services/health_service.dart
+++ b/overdrive/lib/services/health_service.dart
@@ -1,9 +1,9 @@
-/*
+/**
  ##
  ## OverDrive 2026
  ## All Technical rights reserved
  ##
- ## health_service.dart - Backend health-check service.
+ ## health_service.dart - Backend health-check client and response models.
  ##
  */
 

--- a/overdrive/lib/widgets/menu_overlay.dart
+++ b/overdrive/lib/widgets/menu_overlay.dart
@@ -3,6 +3,13 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 import '../core/theme/app_theme.dart';
+import '../pages/calendar/calendar_page.dart';
+import '../pages/championship/championship_page.dart';
+import '../pages/profile/profile_page.dart';
+import '../pages/search/search_page.dart';
+import '../pages/settings/settings_page.dart';
+import '../pages/telemetry/telemetry_page.dart';
+import '../pages/tv/tv_page.dart';
 import '../services/health_service.dart';
 
 class MenuOverlay extends StatefulWidget {
@@ -63,6 +70,11 @@ class _MenuOverlayState extends State<MenuOverlay>
 
     setState(() => _isOpen = false);
     _animationController.reverse();
+  }
+
+  void _openPage(Widget page) {
+    _closeMenu();
+    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
   }
 
   Future<void> _showHealthStatus() async {
@@ -145,7 +157,14 @@ class _MenuOverlayState extends State<MenuOverlay>
                 ignoring: !_isOpen,
                 child: MenuPanel(
                   isLoadingHealth: _isLoadingHealth,
+                  onCalendarTap: () => _openPage(const CalendarPage()),
+                  onChampionshipTap: () => _openPage(const ChampionshipPage()),
                   onHealthTap: _showHealthStatus,
+                  onProfileTap: () => _openPage(const ProfilePage()),
+                  onSearchTap: () => _openPage(const SearchPage()),
+                  onSettingsTap: () => _openPage(const SettingsPage()),
+                  onTelemetryTap: () => _openPage(const TelemetryPage()),
+                  onTvTap: () => _openPage(const TvPage()),
                 ),
               ),
             ),
@@ -195,15 +214,64 @@ class MenuButton extends StatelessWidget {
 class MenuPanel extends StatelessWidget {
   const MenuPanel({
     required this.isLoadingHealth,
+    required this.onCalendarTap,
+    required this.onChampionshipTap,
     required this.onHealthTap,
+    required this.onProfileTap,
+    required this.onSearchTap,
+    required this.onSettingsTap,
+    required this.onTelemetryTap,
+    required this.onTvTap,
     super.key,
   });
 
   final bool isLoadingHealth;
+  final VoidCallback onCalendarTap;
+  final VoidCallback onChampionshipTap;
   final VoidCallback onHealthTap;
+  final VoidCallback onProfileTap;
+  final VoidCallback onSearchTap;
+  final VoidCallback onSettingsTap;
+  final VoidCallback onTelemetryTap;
+  final VoidCallback onTvTap;
 
   @override
   Widget build(BuildContext context) {
+    final actions = <MenuEntry>[
+      MenuEntry(
+        icon: Icons.person_outline,
+        label: 'Profil',
+        onTap: onProfileTap,
+      ),
+      MenuEntry(
+        icon: Icons.settings_outlined,
+        label: 'Settings',
+        onTap: onSettingsTap,
+      ),
+      MenuEntry(
+        icon: Icons.calendar_month_outlined,
+        label: 'Calendar',
+        onTap: onCalendarTap,
+      ),
+      MenuEntry(
+        icon: Icons.emoji_events_outlined,
+        label: 'Championship',
+        onTap: onChampionshipTap,
+      ),
+      MenuEntry(icon: Icons.tv_outlined, label: 'TV', onTap: onTvTap),
+      MenuEntry(
+        icon: Icons.speed_outlined,
+        label: 'Telemetry',
+        onTap: onTelemetryTap,
+      ),
+      MenuEntry(icon: Icons.search, label: 'Search', onTap: onSearchTap),
+      MenuEntry(
+        icon: Icons.monitor_heart_outlined,
+        label: isLoadingHealth ? 'Health...' : 'Health',
+        onTap: onHealthTap,
+      ),
+    ];
+
     return ClipRRect(
       borderRadius: BorderRadius.circular(24),
       child: BackdropFilter(
@@ -220,15 +288,35 @@ class MenuPanel extends StatelessWidget {
             borderRadius: BorderRadius.circular(24),
             border: Border.all(color: Colors.white.withValues(alpha: 0.22)),
           ),
-          child: MenuAction(
-            icon: Icons.monitor_heart_outlined,
-            label: isLoadingHealth ? 'Health...' : 'Health',
-            onTap: onHealthTap,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (final action in actions) ...[
+                MenuAction(
+                  icon: action.icon,
+                  label: action.label,
+                  onTap: action.onTap,
+                ),
+                if (action != actions.last) const SizedBox(height: 8),
+              ],
+            ],
           ),
         ),
       ),
     );
   }
+}
+
+class MenuEntry {
+  const MenuEntry({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
 }
 
 class MenuAction extends StatelessWidget {

--- a/overdrive/lib/widgets/menu_overlay.dart
+++ b/overdrive/lib/widgets/menu_overlay.dart
@@ -1,3 +1,12 @@
+/**
+ ##
+ ## OverDrive 2026
+ ## All Technical rights reserved
+ ##
+ ## menu_overlay.dart - Overlay menu and quick navigation panel.
+ ##
+ */
+
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/overdrive/lib/widgets/menu_overlay.dart
+++ b/overdrive/lib/widgets/menu_overlay.dart
@@ -3,13 +3,6 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 import '../core/theme/app_theme.dart';
-import '../pages/calendar/calendar_page.dart';
-import '../pages/championship/championship_page.dart';
-import '../pages/profile/profile_page.dart';
-import '../pages/search/search_page.dart';
-import '../pages/settings/settings_page.dart';
-import '../pages/telemetry/telemetry_page.dart';
-import '../pages/tv/tv_page.dart';
 import '../services/health_service.dart';
 
 class MenuOverlay extends StatefulWidget {
@@ -72,9 +65,9 @@ class _MenuOverlayState extends State<MenuOverlay>
     _animationController.reverse();
   }
 
-  void _openPage(Widget page) {
+  void _goHome() {
     _closeMenu();
-    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
+    Navigator.of(context).popUntil((route) => route.isFirst);
   }
 
   Future<void> _showHealthStatus() async {
@@ -157,14 +150,8 @@ class _MenuOverlayState extends State<MenuOverlay>
                 ignoring: !_isOpen,
                 child: MenuPanel(
                   isLoadingHealth: _isLoadingHealth,
-                  onCalendarTap: () => _openPage(const CalendarPage()),
-                  onChampionshipTap: () => _openPage(const ChampionshipPage()),
                   onHealthTap: _showHealthStatus,
-                  onProfileTap: () => _openPage(const ProfilePage()),
-                  onSearchTap: () => _openPage(const SearchPage()),
-                  onSettingsTap: () => _openPage(const SettingsPage()),
-                  onTelemetryTap: () => _openPage(const TelemetryPage()),
-                  onTvTap: () => _openPage(const TvPage()),
+                  onHomeTap: _goHome,
                 ),
               ),
             ),
@@ -214,57 +201,19 @@ class MenuButton extends StatelessWidget {
 class MenuPanel extends StatelessWidget {
   const MenuPanel({
     required this.isLoadingHealth,
-    required this.onCalendarTap,
-    required this.onChampionshipTap,
     required this.onHealthTap,
-    required this.onProfileTap,
-    required this.onSearchTap,
-    required this.onSettingsTap,
-    required this.onTelemetryTap,
-    required this.onTvTap,
+    required this.onHomeTap,
     super.key,
   });
 
   final bool isLoadingHealth;
-  final VoidCallback onCalendarTap;
-  final VoidCallback onChampionshipTap;
   final VoidCallback onHealthTap;
-  final VoidCallback onProfileTap;
-  final VoidCallback onSearchTap;
-  final VoidCallback onSettingsTap;
-  final VoidCallback onTelemetryTap;
-  final VoidCallback onTvTap;
+  final VoidCallback onHomeTap;
 
   @override
   Widget build(BuildContext context) {
     final actions = <MenuEntry>[
-      MenuEntry(
-        icon: Icons.person_outline,
-        label: 'Profil',
-        onTap: onProfileTap,
-      ),
-      MenuEntry(
-        icon: Icons.settings_outlined,
-        label: 'Settings',
-        onTap: onSettingsTap,
-      ),
-      MenuEntry(
-        icon: Icons.calendar_month_outlined,
-        label: 'Calendar',
-        onTap: onCalendarTap,
-      ),
-      MenuEntry(
-        icon: Icons.emoji_events_outlined,
-        label: 'Championship',
-        onTap: onChampionshipTap,
-      ),
-      MenuEntry(icon: Icons.tv_outlined, label: 'TV', onTap: onTvTap),
-      MenuEntry(
-        icon: Icons.speed_outlined,
-        label: 'Telemetry',
-        onTap: onTelemetryTap,
-      ),
-      MenuEntry(icon: Icons.search, label: 'Search', onTap: onSearchTap),
+      MenuEntry(icon: Icons.home_outlined, label: 'Home', onTap: onHomeTap),
       MenuEntry(
         icon: Icons.monitor_heart_outlined,
         label: isLoadingHealth ? 'Health...' : 'Health',


### PR DESCRIPTION
## Contexte
L’objectif de ce PR était de créer les instances de pages nécessaires pour les tickets liés au routing et à la navbar.

## Changements
- Création des pages `Profil`, `Settings`, `Calendar`, `Championship`, `TV`, `Telemetry` et `Search`
- Mise en place de pages placeholders simples pour préparer l’intégration future
- Aucun changement sur la navbar
- Aucun changement sur le routing
- Les pages ne sont donc pas encore accessibles via la navigation, mais elles sont désormais prêtes à être branchées pour l’utilisateur

## Vérifications
- [ ] Tests ajoutés ou mis à jour si nécessaire
- [x] Docs mises à jour si nécessaire